### PR TITLE
Ajout de .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignorer les fichiers système de macOS
+.DS_Store


### PR DESCRIPTION
Ajoute un .gitignore pour ne pas envoyer les fichiers macOS de type DS_Store